### PR TITLE
Workaround for mxSignpost not found on App Launch

### DIFF
--- a/Sources/iOS-Common-Libraries/Extensions/NordicLog.swift
+++ b/Sources/iOS-Common-Libraries/Extensions/NordicLog.swift
@@ -127,7 +127,7 @@ public extension NordicLog {
 
     @inline(__always) private func mxEvent(name: StaticString, line: String) {
         #if os(iOS) || targetEnvironment(macCatalyst)
-        mxSignpost(.event, log: mxLog, name: name, signpostID: OSSignpostID(log: mxLog), "%{PUBLIC}@", [line])
+        // mxSignpost(.event, log: mxLog, name: name, signpostID: OSSignpostID(log: mxLog), "%{PUBLIC}@", [line])
         #endif
     }
     
@@ -140,12 +140,12 @@ public extension NordicLog {
                 os_signpost(.begin, log: poiLog, name: name, signpostID: signpostId)
             }
             #if os(iOS) || targetEnvironment(macCatalyst)
-            mxSignpost(.begin, log: mxLog, name: name, signpostID: signpostId)
+            // mxSignpost(.begin, log: mxLog, name: name, signpostID: signpostId)
             #endif
         } else {
             os_signpost(.begin, log: poiLog, name: name)
             #if os(iOS) || targetEnvironment(macCatalyst)
-            mxSignpost(.begin, log: mxLog, name: name)
+            // mxSignpost(.begin, log: mxLog, name: name)
             #endif
         }
     }
@@ -159,12 +159,12 @@ public extension NordicLog {
                 os_signpost(.end, log: poiLog, name: name, signpostID: signpostId)
             }
             #if os(iOS) || targetEnvironment(macCatalyst)
-            mxSignpost(.end, log: mxLog, name: name, signpostID: signpostId)
+            // mxSignpost(.end, log: mxLog, name: name, signpostID: signpostId)
             #endif
         } else {
             os_signpost(.end, log: poiLog, name: name)
             #if os(iOS) || targetEnvironment(macCatalyst)
-            mxSignpost(.end, log: mxLog, name: name)
+            // mxSignpost(.end, log: mxLog, name: name)
             #endif
         }
     }


### PR DESCRIPTION
This happens for apps built using Xcode 26.4 that are running iOS versions older than 26.4 so, everybody mostly. It's not fixed in 26.5b1 and neither is it listed in the Release Notes for 26.4 nor in 26.5b1. Shame on you, Apple.