### PR TITLE
Better HttpResponse Error Information

### DIFF
--- a/Sources/iOS-Common-Libraries/Network/Network.swift
+++ b/Sources/iOS-Common-Libraries/Network/Network.swift
@@ -90,9 +90,13 @@ public extension Network {
                         #if DEBUG
                         logDebug("\(request): \(responseDataAsString)")
                         #endif
-                        throw URLError(.cannotParseResponse)
+                        throw URLError(.unknown, userInfo: [
+                            "httpStatusCode": httpResponse.statusCode,
+                            "httpResponse": HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode),
+                            "response": responseDataAsString
+                        ])
                     } else {
-                        throw URLError(.badServerResponse)
+                        throw URLError(.cannotParseResponse)
                     }
                 }
             }


### PR DESCRIPTION
URLError's Code is not... I don't think it's helpful. I think it's a lot better if we just provide all of the info and allow downstream users of the API to check the status code on their own. I think this is the best we can do that's extensible. It's sad that URLError does not lend itself to this, perhaps we need a rewrite.