### PR TITLE
Added a TODO to fix InlinePicker causing unnecessary SwiftUI layouts

### DIFF
--- a/Sources/iOS-Common-Libraries/Views/InlinePicker.swift
+++ b/Sources/iOS-Common-Libraries/Views/InlinePicker.swift
@@ -22,6 +22,7 @@ public struct InlinePicker<T: Hashable & Equatable>: View {
     private let systemImage: String?
     private let selectedValue: Binding<T>
     private let possibleValues: [T]
+    // TODO: Remove onChange because it breaks SwiftUI comparison, causing it to make unnecessary layouts when nothing else has changed.
     private let onChange: OnChange?
     
     // MARK: Init


### PR DESCRIPTION
SwiftUI cannot compare closures in init, therefore, it always assumes that the child has changed, and this can trigger a lot of other subviews to refresh as well. Marking it as a TODO to make it happen, but it might not last long.