### PR TITLE
Ported UIStackView & AutoLayout helpers from nRF Connect

### DIFF
--- a/Sources/iOS-Common-Libraries/Extensions/AutoLayout.swift
+++ b/Sources/iOS-Common-Libraries/Extensions/AutoLayout.swift
@@ -1,0 +1,70 @@
+//
+//  AutoLayout.swift
+//  nRF-Connect
+//  iOSCommonLibraries
+//
+//  Created by Dinesh Harjani on 17/12/2018.
+//  Created by Dinesh Harjani on 29/05/2026.
+//  Copyright © 2026 Nordic Semiconductor. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - Safe Anchor(s)
+
+public extension UIView {
+
+    var safeTopAnchor: NSLayoutYAxisAnchor {
+        safeAreaLayoutGuide.topAnchor
+    }
+
+    var safeLeadingAnchor: NSLayoutXAxisAnchor {
+        safeAreaLayoutGuide.leadingAnchor
+    }
+
+    var safeTrailingAnchor: NSLayoutXAxisAnchor {
+        safeAreaLayoutGuide.trailingAnchor
+    }
+
+    var safeWidthAnchor: NSLayoutDimension {
+        safeAreaLayoutGuide.widthAnchor
+    }
+    
+    var safeBottomAnchor: NSLayoutYAxisAnchor {
+        safeAreaLayoutGuide.bottomAnchor
+    }
+    
+    var safeHeightAnchor: NSLayoutDimension {
+        safeAreaLayoutGuide.heightAnchor
+    }
+}
+
+// MARK: - addForAutoLayout()
+
+public extension UIView {
+
+    /**
+     Adds all subviews to the current `UIView`, but also sets ``translatesAutoresizingMaskIntoConstraints``
+     for every added subview to `false`. This is because by default it's set to `true`, which means
+     "Springs and Struts" behaviour via automatic constraints. That's why we turn it off.
+     */
+    func addForAutoLayout(subviews: [UIView]) {
+        subviews.forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            addSubview($0)
+        }
+    }
+}
+
+// MARK: - Sequence
+
+public extension Sequence where Element == NSLayoutConstraint {
+    
+    func activateAll() {
+        forEach { $0.isActive = true }
+    }
+    
+    func deactivateAll() {
+        forEach { $0.isActive = false }
+    }
+}

--- a/Sources/iOS-Common-Libraries/Extensions/UIStackView.swift
+++ b/Sources/iOS-Common-Libraries/Extensions/UIStackView.swift
@@ -1,0 +1,42 @@
+//
+//  UIStackView.swift
+//  nRF-Connect
+//  iOSCommonLibraries
+//
+//  Created by Dinesh Harjani on 27/04/2020.
+//  Created by Dinesh Harjani on 29/05/2026.
+//  Copyright © 2026 Nordic Semiconductor. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - UIStackView
+
+public extension UIStackView {
+    
+    static func inColumns(_ columns: UIView..., distribution: Distribution = .fill, alignment: Alignment = .fill, spacing: CGFloat = 8.0) -> UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = distribution
+        stackView.alignment = alignment
+        stackView.spacing = spacing
+        
+        columns.forEach { column in
+            stackView.addArrangedSubview(column)
+        }
+        columns.first?.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        return stackView
+    }
+    
+    static func inRows(_ rows: UIView..., alignment: Alignment = .fill, spacing: CGFloat = 8.0) -> UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = alignment
+        stackView.spacing = spacing
+        rows.forEach { row in
+            stackView.addArrangedSubview(row)
+        }
+        return stackView
+    }
+}


### PR DESCRIPTION
These were previously not ported over because most of our apps are nowadays SwiftUI-powered. But nRF Connect Device Manager is switching from Storyboards to AutoLayout so, these are now helpful over there.