### PR TITLE
Added isOK to NetworkResponse struct

### DIFF
--- a/Sources/iOS-Common-Libraries/Network/NetworkResponse.swift
+++ b/Sources/iOS-Common-Libraries/Network/NetworkResponse.swift
@@ -23,4 +23,10 @@ public struct NetworkResponse {
         self.code = code
         self.data = data
     }
+    
+    // MARK: API
+    
+    public var isOK: Bool {
+        200..<300 ~= code
+    }
 }


### PR DESCRIPTION
This is useful in cases where the Network API user does not attempt a Codable / JSON Decode but instead wants the specific NetworkResponse variant directly. However, upon further inspection it's a bit pointless because we're currently only returning NetworkResponse if it is success. Anyway...