### PR TITLE
Extended BasicHTTPResponse for added reliability

### DIFF
--- a/Sources/iOS-Common-Libraries/Network/Network.swift
+++ b/Sources/iOS-Common-Libraries/Network/Network.swift
@@ -204,4 +204,21 @@ public struct BasicHTTPResponse: HTTPResponse, LocalizedError {
     public var errorDescription: String? { error }
     public var recoverySuggestion: String? { error }
     public var helpAnchor: String? { "Try Postman or ask Roshee for help." }
+    
+    // MARK: init
+    
+    public init(success: Bool, error: String?) {
+        self.success = success
+        self.error = error
+    }
+    
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let errorValue = try container.decodeIfPresent(String.self, forKey: .error)
+        let decodedSuccessValue = try? container.decode(Bool.self, forKey: .success)
+        let successValue: Bool = decodedSuccessValue ?? (errorValue == nil)
+ 
+        self.init(success: successValue, error: errorValue)
+    }
 }


### PR DESCRIPTION
It might be that a response contains no specific Error / success value, in which case, we should assume this is a success scenario. So I thought, to add or improve the reliability of the API, that we should extended it this way. Conversely, if an "error" is found, we should assume this is not a success. Favouring the decoded value, of course, if there is one.