### PR TITLE
Guard remaining UIKit imports for macOS builds

### DIFF
--- a/Sources/iOS-Common-Libraries/Extensions/AutoLayout.swift
+++ b/Sources/iOS-Common-Libraries/Extensions/AutoLayout.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2026 Nordic Semiconductor. All rights reserved.
 //
 
+#if os(iOS) || targetEnvironment(macCatalyst)
 import UIKit
 
 // MARK: - Safe Anchor(s)
@@ -68,3 +69,4 @@ public extension Sequence where Element == NSLayoutConstraint {
         forEach { $0.isActive = false }
     }
 }
+#endif

--- a/Sources/iOS-Common-Libraries/Extensions/UIStackView.swift
+++ b/Sources/iOS-Common-Libraries/Extensions/UIStackView.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2026 Nordic Semiconductor. All rights reserved.
 //
 
+#if os(iOS) || targetEnvironment(macCatalyst)
 import UIKit
 
 // MARK: - UIStackView
@@ -40,3 +41,4 @@ public extension UIStackView {
         return stackView
     }
 }
+#endif

--- a/Sources/iOS-Common-Libraries/Utilities/Haptic.swift
+++ b/Sources/iOS-Common-Libraries/Utilities/Haptic.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2026 Nordic Semiconductor. All rights reserved.
 //
 
+#if os(iOS) || targetEnvironment(macCatalyst)
 import UIKit
 
 // MARK: - Haptic
@@ -62,3 +63,4 @@ public struct Haptic {
         }
     }
 }
+#endif


### PR DESCRIPTION
AutoLayout.swift, UIStackView.swift, and Haptic.swift unconditionally imported UIKit despite this package's own Package.swift declaring macOS 10.15+ support - the other three UIKit-touching files (UIView.swift, NordicLog.swift, UIColor.swift) already guard correctly with `#if os(iOS) || targetEnvironment(macCatalyst)`. Adds the same guard to the remaining three so the package actually builds on macOS.

I used iOSMcuManagerLibrary in a macOS/SwiftUI project. Although I'm not using any of the Nordic UI code, iOSMcuManagerLibrary drags this library in as a dependency, forcing me to modify these files.